### PR TITLE
Add historical call

### DIFF
--- a/.github/workflows/get-history.yml
+++ b/.github/workflows/get-history.yml
@@ -64,7 +64,7 @@ jobs:
                     echo "Error: Invalid end date format. Expected YYYY-MM-DD."
                     exit 1
                 fi
-                if [[ "$START_DATE" >= "$END_DATE" ]]; then
+                if [[ "$START_DATE" > "$END_DATE" || "$START_DATE" == "$END_DATE" ]]; then
                     echo "Error: Start date must be before end date."
                     exit 1
                 fi

--- a/.github/workflows/get-history.yml
+++ b/.github/workflows/get-history.yml
@@ -1,0 +1,156 @@
+name: Generate Historical Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+        start_date:
+          description: 'Start date for historical data (YYYY-MM-DD) - required, e.g., 2026-01-01'
+          required: true
+          type: string
+        end_date:
+          description: 'End date for historical data (YYYY-MM-DD) - defaults to today if not provided'
+          required: false
+          default: ''
+          type: string
+        org_name:
+          description: 'GitHub organization name'
+          required: false
+          type: string
+          default: 'DSACMS'
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    generate-historical-data:
+        runs-on: ubuntu-latest
+        
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
+            with:
+              fetch-depth: 0
+    
+          - name: Set up Python
+            uses: actions/setup-python@v4
+            with:
+              python-version: '3.11'
+    
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              pip install PyGithub
+
+          - name: Resolve dates
+            id: dates
+            run: |
+              START_DATE="${{ github.event.inputs.start_date }}"
+              END_DATE="${{ github.event.inputs.end_date }}"
+
+                if [ -z "$END_DATE" ]; then
+                    END_DATE=$(date -u +%Y-%m-%d)
+                    echo "No end date provided, defaulting to today: $END_DATE"
+                fi
+
+                echo "start_date=$START_DATE" >> $GITHUB_OUTPUT
+                echo "end_date=$END_DATE" >> $GITHUB_OUTPUT
+
+                if [[ ! "$START_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                    echo "Error: Invalid start date format. Expected YYYY-MM-DD."
+                    exit 1
+                fi
+                if [[ ! "$END_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                    echo "Error: Invalid end date format. Expected YYYY-MM-DD."
+                    exit 1
+                fi
+                if [[ "$START_DATE" >= "$END_DATE" ]]; then
+                    echo "Error: Start date must be before end date."
+                    exit 1
+                fi
+                
+          - name: Generate historical changelog data
+            env:
+              GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+              START_DATE: ${{ steps.dates.outputs.start_date }}
+              END_DATE: ${{ steps.dates.outputs.end_date }}
+              ORG_NAME: ${{ github.event.inputs.org_name }}
+            run: |
+              python scripts/generate_changelog_historical.py
+
+          - name: Upload historical data artifact
+            uses: actions/upload-artifact@v4
+            with:
+              name: historical-changelog-${{ steps.dates.outputs.start_date }}-to-${{ steps.dates.outputs.end_date }}
+              path: changelog_data/data/historical_changelog_*.json
+              if-no-files-found: error
+
+          - name: Create Pull Request with Historical Summary
+            env: 
+              GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+            run: |
+              START_DATE="${{ steps.dates.outputs.start_date }}"
+              END_DATE="${{ steps.dates.outputs.end_date }}"
+              BRANCH_NAME="historical-changelog-${START_DATE}-to-${END_DATE}"
+              DATA_FILE="changelog_data/data/historical_changelog_${START_DATE}_to_${END_DATE}.json"
+
+              git config --local user.email "action@github.com"
+              git config --local user.name "GitHub Action" 
+
+              if git ls-remote --exit-code origin $BRANCH_NAME; then
+                echo "Branch $BRANCH_NAME already exists. Checking out existing branch..."
+                git fetch origin $BRANCH_NAME
+                git checkout $BRANCH_NAME
+                git pull origin $BRANCH_NAME
+              else
+                echo "Creating new branch $BRANCH_NAME..."
+                git checkout -b $BRANCH_NAME
+              fi
+
+              git add changelog_data/
+
+              if git diff-index --quiet HEAD --; then
+                echo "No changes to commit, file already exists in the branch."
+              else
+                git commit -sm "Add historical changelog data from $START_DATE to $END_DATE"
+                git push --set-upstream origin $BRANCH_NAME
+              fi
+
+              if gh pr view $BRANCH_NAME --json number 2>/dev/null; then
+                echo "Pull request for branch $BRANCH_NAME already exists, skipping PR creation."
+              else
+                gh api repos/${{ github.repository }}/labels \
+                  -f name='historical-changelog-data' -f color='0E8A16' || true
+                gh api repos/${{ github.repository }}/labels \
+                  -f name='automated' -f color='FB04D4' || true
+
+                PR_TITLE="Add historical changelog data from $START_DATE to $END_DATE"
+                PR_BODY=$(cat <<EOF
+              ## Historical Changelog Data
+              
+              **Period:**: \`$START_DATE\` to \`$END_DATE\`
+              **Organization**: ${{ github.event.inputs.org_name }}
+              **Generated**: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+              
+              ### Contents
+              
+              Activity data for the specific period above has been generated and added to the repository.
+
+              - **Data File**: \`$DATA_FILE\`
+              - **Description**: This file contains a comprehensive changelog of all activities (PRs, issues, commits) across all repositories in the specified organization during the defined period. \
+              It is intended for historical analysis and reference.   
+              EOF
+              )
+
+                gh pr create \
+                  --title "$PR_TITLE" \
+                  --body "$PR_BODY" \
+                  --base main \
+                  --head $BRANCH_NAME \
+                  --label "historical-changelog-data,automated" || \
+                gh pr create \
+                  --title "$PR_TITLE" \
+                  --body "$PR_BODY" \
+                  --base main \
+                  --head $BRANCH_NAME
+              fi

--- a/scripts/generate_changelog_historical.py
+++ b/scripts/generate_changelog_historical.py
@@ -1,0 +1,88 @@
+"""
+Historical Changelog Data Generation Script
+"""
+
+import os
+import sys
+import subprocess
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from util import ChangelogGenerator # type: ignore
+
+
+def parse_dates(value: str, label: str) -> str:
+    """Validate an ISO date string."""
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise ValueError(
+            f"Invalid {label} date format: '{value}'. Expected format: YYYY-MM-DD"
+        )
+    return value
+
+
+def main() -> None:
+    """Main function to generate historical changelog data."""
+    start_raw = os.getenv("START_DATE") or (sys.argv[1] if len(sys.argv) > 1 else None)
+    end_raw = os.getenv("END_DATE") or (sys.argv[2] if len(sys.argv) > 2 else None)
+
+    if not start_raw or not start_raw.strip():
+        print(
+            "Error: START_DATE is required. \n"
+            "Provide it as an environment variable or pass it as the first input argument:\n"
+            "python scripts/generate_changelog_historical.py <start_date> [end_date]"
+        )
+        sys.exit(1)
+
+    try:
+        start_date = parse_dates(start_raw.strip(), "START_DATE")
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    if end_raw and end_raw.strip():
+        try:
+            end_date = parse_dates(end_raw.strip(), "END_DATE")
+        except ValueError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+    else:
+        end_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        print(f"END_DATE not provided. Defaulting to current date: {end_date}")
+
+    if start_date >= end_date:
+        print("Error: START_DATE ({start_date}) must be earlier than END_DATE ({end_date}).")
+        sys.exit(1)
+
+    token = os.getenv("GH_TOKEN") or os.getenv("REPOLINTER_AUTO_TOKEN")
+    if not token:
+        print("Error: GitHub token not found. Please set GH_TOKEN or REPOLINTER_AUTO_TOKEN environment variable.")
+        sys.exit(1)
+
+    org_name = os.getenv("ORG_NAME", "DSACMS")
+
+    output_dir = "changelog_data/data"
+    os.makedirs(output_dir, exist_ok=True)
+    filename = os.path.join(output_dir, f"changelog_{start_date}_to_{end_date}.json")
+
+    print(f"Generating historical changelog data for {org_name} from {start_date} to {end_date}...")
+    print(f"Organization: {org_name}")
+    print(f"Period: {start_date} to {end_date}")
+    print(f"Output file: {filename}")
+    print("-" * 60)
+
+    gen = ChangelogGenerator(token, filename=filename, log_history_start=start_date)
+    saved = gen.get_and_save_data(org_name=org_name)
+
+    if saved:
+        print("-" * 60)
+        print(f"Historical changelog data generated and saved to {filename}")
+    else:
+        print("Failed to generate historical changelog data.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_changelog_historical.py
+++ b/scripts/generate_changelog_historical.py
@@ -7,7 +7,7 @@ import sys
 import subprocess
 from datetime import datetime, timezone
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from util import ChangelogGenerator # type: ignore
 
@@ -65,7 +65,7 @@ def main() -> None:
 
     output_dir = "changelog_data/data"
     os.makedirs(output_dir, exist_ok=True)
-    filename = os.path.join(output_dir, f"changelog_{start_date}_to_{end_date}.json")
+    filename = os.path.join(output_dir, f"historical_changelog_{start_date}_to_{end_date}.json")
 
     print(f"Generating historical changelog data for {org_name} from {start_date} to {end_date}...")
     print(f"Organization: {org_name}")


### PR DESCRIPTION
# Historical Changelog Generator

## Problem
The existing changelog workflow runs on a weekly schedule and captures a weeks worth of activity. There is no way to generate a snapshot of data over a longer or custom period of time. This is something needed for archival analysis to assess repository activity over months rather than weeks.

## Solution 
Added a manually triggered GitHub Actions workflow with two inputs, a required `start_date` and an optional `end_date` (defaults to today). The workflow calls a new entry point script, `generate_changelog_historical.py`, then reuses the existing  `ChangelogGenerator` class from `util.py` to fetch commits, issues, PRs, releases, contributors and changelog entries across a specific date range. The output is a raw JSON file named `historical_changelog_${START_DATE}_to_${END_DATE}.json` and opened as a PR with no summary or comms content generated.

## Result
Users can now trigger a historical data pull from the GitHub Actions UI for any date range by supplying a start date. The output file has the same structure as the existing weekly changelog JSON, making it immediately compatible to use with our already existing archiving workflow.

## Test
- Fork repo into a test repository ex. `DinneK/super-changelog-testing-fork`
- Merge changes in the test repo
- Trigger Generate Historical Changelog 
  - Add start date ex. 2026-01-01
  - Add end date, if desired. End date is today by default
  - Organization is DSACMS by default
- PR should be created titled: "Add historical changelog data from {START_DATE} to {END_DATE}
  - PR should include one file titled: `changelog_data/data/historical_changelog_START_DATE_to_END_DATE.json`