### PR TITLE
Add workflow call for action dispatch

### DIFF
--- a/.github/workflows/get-history.yml
+++ b/.github/workflows/get-history.yml
@@ -17,6 +17,23 @@ on:
           required: false
           type: string
           default: 'DSACMS'
+      
+  workflow_call:
+    inputs:
+        start_date:
+          required: true
+          type: string
+        end_date:
+          required: false
+          default: ''
+          type: string
+        org_name:
+          required: false
+          type: string
+          default: 'DSACMS'
+    secrets:
+        REPOLINTER_AUTO_TOKEN:
+          required: true
 
 permissions:
     contents: write


### PR DESCRIPTION
## Problem
The current `get-history.yml` action can only be called within the Super-changelog repository.

## Solution 
Add a `workflow_call` to the action to allow use in other repos.

## Result 
`get-history.yml` can now be used in other repositories such as `archival-identifier`

## Test
Tested in `archival-identifier`.