### PR TITLE
Add properties

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -141,6 +141,7 @@ class ChangelogGenerator:
                             "url": issue.html_url,
                             "created_at": issue.created_at.isoformat(),
                             "state": issue.state,
+                            "author": issue.user.login if issue.user else None,
                             "is_new": issue.created_at.replace(tzinfo=None) >= self.start_date
                         })
                     else:
@@ -155,6 +156,7 @@ class ChangelogGenerator:
                                 "merged_at": pr.merged_at.isoformat() if pr.merged_at else None,
                                 "state": pr.state,
                                 "merged": pr.is_merged(),
+                                "author": pr.user.login if pr.user else None,
                                 "is_new": pr.created_at.replace(tzinfo=None) >= self.start_date
                             })
                         except Exception as e:
@@ -215,10 +217,18 @@ class ChangelogGenerator:
         for repo in org.get_repos(type="public"):
             total_repos += 1
             print(f"Processing repo: {repo.name}")
+            try:
+                topics = repo.get_topics()
+            except Exception as e:
+                print(f"Error getting topics for {repo.name}: {e}")
+                topics = []
+
             repo_data = {
                 "name": repo.name,
                 "url": repo.html_url,
                 "description": repo.description,
+                "archived": repo.archived,
+                "topics": topics,
                 "issues": [],
                 "pulls": [],
                 "commits": [],


### PR DESCRIPTION
## Problem 
The current `generate_changelog_historical.py` does not generate authors for pull requests and issues. It also doesn't check to see if a repository has been archived in any way.

## Solution
- Add properties of "author" within the issues requests and pull requests.
- Add a call for topics to return both topics and the archived tag.

## Result 
- Authors are now returned and available within the JSON file for both issues and PRs.
- A new property of "archived" is called and returns a boolean, ex `archived": true`

## Test
- Create or use an already existing test repository
- Merge `Add-properties` branch into main of test repostitory
- Run workflow "Get History"
- Enter inputs
- PR should return JSON file
Example:
```
{
  "repos": [
    {
      "name": ".github",
      "url": "https://github.com/DSACMS/.github",
      "description": "Template repo for CMS Open Source Projects",
      "archived": false,
      "topics": [
        "template"
      ],
      "issues": [
        {
          "title": "Use new Issue Template Features of GitHub",
          "url": "https://github.com/DSACMS/.github/issues/2",
          "created_at": "2024-05-28T15:36:38+00:00",
          "state": "closed",
          "author": "decause-gov",
          "is_new": false
        }
      ],
      "pulls": [
        {
          "title": "Add speaking",
          "url": "https://github.com/DSACMS/.github/pull/13",
          "created_at": "2026-05-05T17:18:06+00:00",
          "updated_at": "2026-05-05T17:41:52+00:00",
          "merged_at": "2026-05-05T17:41:52+00:00",
          "state": "closed",
          "merged": true,
          "author": "DinneK",
          "is_new": true
        },...
```