### PR TITLE
Add GitHub App workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,6 +19,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      
+      - name: Generate app token
+        uses: actions/create-github-token@v4
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -32,7 +39,7 @@ jobs:
 
       - name: Generate weekly changelog
         env:
-          GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python scripts/generate_changelog_weekly.py
       
@@ -62,6 +69,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate app token
+        uses: actions/create-github-token@v4
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -80,7 +94,7 @@ jobs:
 
       - name: Create Pull Request with Full Summary
         env: 
-          GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Get latest summary files
           TIMESTAMP=$(date +"%Y-%m-%d")
@@ -152,6 +166,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate app token
+        uses: actions/create-github-token@v4
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -170,7 +191,7 @@ jobs:
 
       - name: Create Condensed Pull Request
         env: 
-          GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Get latest condensed summary files
           TIMESTAMP=$(date +"%Y-%m-%d")

--- a/.github/workflows/get-history.yml
+++ b/.github/workflows/get-history.yml
@@ -48,6 +48,13 @@ jobs:
             uses: actions/checkout@v4
             with:
               fetch-depth: 0
+
+          - name: Generate app token
+            uses: actions/create-github-token@v4
+            id: app-token
+            with:
+              app-id: ${{ vars.APP_ID }}
+              private-key: ${{ secrets.APP_PRIVATE_KEY }}
     
           - name: Set up Python
             uses: actions/setup-python@v4
@@ -88,7 +95,7 @@ jobs:
                 
           - name: Generate historical changelog data
             env:
-              GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+              GH_TOKEN: ${{ steps.app-token.outputs.token }}
               START_DATE: ${{ steps.dates.outputs.start_date }}
               END_DATE: ${{ steps.dates.outputs.end_date }}
               ORG_NAME: ${{ github.event.inputs.org_name }}
@@ -104,7 +111,7 @@ jobs:
 
           - name: Create Pull Request with Historical Summary
             env: 
-              GH_TOKEN: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+              GH_TOKEN: ${{ steps.app-token.outputs.token }}
             run: |
               START_DATE="${{ steps.dates.outputs.start_date }}"
               END_DATE="${{ steps.dates.outputs.end_date }}"


### PR DESCRIPTION
## Problem
Current secrets, such as a PAT, required to run GitHub Actions, expire or become obsolete when a the owner of the PAT or Token leaves DSAC. This causes action and workflows to break.

## Solution
Create a GitHub App to generate a token for the organization, so permissions are not lost or do not expire. 

## Result
A new GitHub token is created with the org as the owner rather than an individual. No longer breaks when a person leaves. Token auto-rotates once per hour. Audit trail is now `super-changelog-bot`.