### PR TITLE
removed logic to only append repos with activity to changelog

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -321,9 +321,12 @@ class ChangelogGenerator:
             except Exception as e:
                 print(f"Error fetching releases for {repo.name}: {str(e)}")
             
+            """
             if (repo_data["issues"] or repo_data["pulls"] or
                 repo_data["commits"] or repo_data["changelog_entries"]) or repo_data["releases"]:
                 data["repos"].append(repo_data)
+            """
+            data["repos"].append(repo_data)
         
         data["total_repo_count"] = total_repos
         return data


### PR DESCRIPTION
### **Problem**

When `super-changelog` ran its historical changelog generation script for time windows where repositories had **zero development activity** (no issues, PRs, commits, changelog entries, or releases within the period), it excluded those repositories entirely from the `repos` output array.

Because downstream workflows—such as `archival-identifier`—rely on `super-changelog`'s output to evaluate metadata for *all* organization repositories, dropping inactive repositories resulted in empty JSON payloads (`"repos": []`). Consequently, downstream tools produced blank issue tables instead of correctly reporting 0 activity metrics for inactive repositories.

---

### **Solution**

Updated `scripts/util.py` inside `get_data()` to ensure that **all repositories** fetched for an organization are appended to the `data["repos"]` output list, regardless of whether they contained activity within the specified timeframe.

Specifically, removed the conditional filtering logic (`if repo_data["issues"] or repo_data["pulls"] ...`) so that inactive repositories are still included as structured JSON objects containing empty activity arrays.

---

### **Result**

* `super-changelog` now outputs a complete JSON array containing every repository in the target GitHub organization for the given timeframe.
* Repositories with no activity during the specified range are explicitly returned with empty activity lists (`"issues": []`, `"commits": []`, etc.) rather than being omitted entirely.
* Downstream workflows (such as `archival-identifier`) can now successfully iterate through all organization repositories and render accurate metrics (even when development activity is 0) without generating empty tables.
* https://github.com/DSACMS/testing-repository/issues/86

---

### **Test Plan**

* [ ] **Local Script Execution:**
* Run the historical changelog generation script against a test organization (e.g. natalialuzuriaga-testing-org) containing inactive repositories for a date range with zero development activity (e.g., 06/01 to 06/30).
* Verify that the resulting JSON output includes all repositories in the `repos` array with empty activity lists instead of returning `"repos": []`.


* [ ] **Integration Testing (Workflow):**
* Trigger the `archival-identifier.yml` workflow in a test repository using the updated `super-changelog` script for a 1-month window with no activity.
* Confirm from the workflow execution logs that the iteration step (`Analyzing <repo>: Criticality Score`) logs all repositories.
* Verify that the generated GitHub Issue populates the table with zeroed out/empty metrics instead of creating a blank table.

---
### AI Usage

- Generated AI was not used in this contribution
